### PR TITLE
fix null matching on objects with null id

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,9 @@ var znFilterMatcher = (function() {
 			} else if (recordValue.id !== undefined) {
 				recordValue = recordValue.id;
 			}
-		} else if (recordValue === null || recordValue === undefined) {
+		}
+
+		if (recordValue === null || recordValue === undefined) {
 			return '';
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zn-filter-matcher",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Zengine Filter Matcher",
   "main": "index.js",
   "scripts": {

--- a/tests/index-spec.js
+++ b/tests/index-spec.js
@@ -66,6 +66,27 @@ describe('znFilterMatcher', function() {
 
 			});
 
+			it('should return true with null object', function() {
+
+				record.field1 = {
+					id: null,
+					name: null
+				};
+
+				filter = {
+					and: [
+						{
+							prefix: '',
+							attribute: 'field1',
+							value: null
+						}
+					]
+				};
+
+				expect(znFilterMatcher.recordMatchesFilter(record, filter)).toBe(true);
+
+			});
+
 		});
 
 		/**
@@ -114,6 +135,27 @@ describe('znFilterMatcher', function() {
 				record.field1 = null;
 
 				expect(znFilterMatcher.recordMatchesFilter(record, filter)).toBe(true);
+
+			});
+
+			it('should return true with null object', function() {
+
+				record.field1 = {
+					id: null,
+					name: null
+				};
+
+				filter = {
+					and: [
+						{
+							prefix: 'not',
+							attribute: 'field1',
+							value: 'null'
+						}
+					]
+				};
+
+				expect(znFilterMatcher.recordMatchesFilter(record, filter)).toBe(false);
 
 			});
 


### PR DESCRIPTION
- record with value '{id: null}' should match null filter value